### PR TITLE
Initial etcd quoin

### DIFF
--- a/etcd/bastion.tf
+++ b/etcd/bastion.tf
@@ -1,0 +1,49 @@
+/*
+* ------------------------------------------------------------------------------
+* Resources
+* ------------------------------------------------------------------------------
+*/
+
+# Security Group for Bastion instances to use
+# Bastions are on-demand when needed.
+# The vpc variables are declared in main.tf
+resource "aws_security_group" "bastion" {
+  name   = "${format("%s-bastion-%s", var.name, element(split("-", var.vpc_id), 1))}"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    protocol    = -1
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol    = -1
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["${var.vpc_cidr}"]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.name}-bastion"
+  }
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Outputs
+* ------------------------------------------------------------------------------
+*/
+
+# The bastion security group ID
+output "bastion_security_group_id" {
+  value = "${aws_security_group.bastion.id}"
+}

--- a/etcd/bootstrapper/s3-cloudconfig-bootstrap.sh
+++ b/etcd/bootstrapper/s3-cloudconfig-bootstrap.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# This is a CoreOS Cluster Bootstrap script. It is passed in as 'user-data' file during the machine build.
+# Then the script is excecuted to download the CoreOs "cloud-config.yaml" file  and "intial-cluster" files.
+# These files  will configure the system to join the CoreOS cluster. The second stage cloud-config.yaml can
+# be changed to allow system configuration changes without having to rebuild the system. All it takes is a reboot.
+# If this script changes, the machine will need to be rebuild (user-data change)
+
+# Convention:
+# 1. A bucket should exist that contains role-based cloud-config.yaml
+#  e.g. concur-<cluster-name>-cloudinit/<roleProfile>/cloud-config.yaml
+# 2. All machines should have instance role profile, with a policy that allows readonly access to this bucket.
+
+# Placement
+region="$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document/ | jq -r '.region')"
+availability_zone="$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document/ | jq -r '.availabilityZone')"
+
+# Bucket
+bucket="concur-${name}"
+
+# Determine our role
+role="etcd"
+
+work_dir="/root/cloudinit"
+mkdir -m 700 -p "$work_dir"
+
+# CloudInit Locations
+cloudinit_src="s3://$bucket/cloudinit/$role"
+cloudinit_dst="$work_dir"
+cloudinit_common_tls_src="s3://$bucket/cloudinit/common/tls"
+cloudinit_tls_dst="$work_dir/tls"
+
+# pull the IMAGE if not loaded
+image="quay.io/concur_platform/awscli:0.1.1"
+docker history "$image" > /dev/null 2>&1 || docker pull "$image"
+
+# Sync CloudInit
+src="$cloudinit_src"
+dst="$cloudinit_dst"
+cmd="aws --region $region s3 cp --recursive $src $dst"
+docker run --rm --name s3cp-cloudinit -v "$work_dir":"$work_dir" "$image" /bin/bash -c "$cmd"
+
+# Sync Common TLS Assets
+src="$cloudinit_common_tls_src"
+dst="$cloudinit_tls_dst"
+cmd="aws --region $region s3 cp --recursive $src $dst"
+docker run --rm --name s3cp-common-tls -v "$work_dir":"$work_dir" "$image" /bin/bash -c "$cmd"
+
+# Replace placeholders inside cloud-config
+sed -i -- 's/\\$private_ipv4/'$private_ipv4'/g; s/\\$public_ipv4/'$public_ipv4'/g' $work_dir/cloud-config.yaml
+
+# Decode TLS Assets
+echo "Decoding TLS assets"
+for encPemFile in $work_dir/tls/*.pem.enc.base; do
+  echo "Decoding $encPemFile"
+  cat $encPemFile | base64 -d > $${encPemFile%.base}
+done
+
+# Decrypt TLS Assets
+docker run --rm --name decrypt-tls \
+  -e REGION=$region \
+  -e WORK_DIR=$work_dir/tls \
+  -v $work_dir/tls:$work_dir/tls \
+  quay.io/concur_platform/awscli:0.1.1 /bin/bash \
+    -ec \
+    'echo Decrypting TLS assets; \
+    shopt -s nullglob; \
+    for encPemFile in $WORK_DIR/*.pem.enc; do \
+      echo Decrypting $encPemFile; \
+      /usr/bin/aws \
+        --region $REGION kms decrypt \
+        --ciphertext-blob fileb://$encPemFile \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $${encPemFile%.enc}; \
+    done; \
+    cat $WORK_DIR/intermediate-ca.pem $WORK_DIR/root-ca.pem > $WORK_DIR/ca-chain.pem; \
+    echo done.'
+
+# Create /etc/quoin-environment
+quoin_cluster_environment='/etc/quoin-environment'
+if [ ! -f "$quoin_cluster_environment" ];
+then
+  echo "QUOIN_NAME=${name}" > /etc/quoin-environment
+  echo "REGION=$region" >> /etc/quoin-environment
+  echo "AVAILABILITY_ZONE=$availability_zone" >> /etc/quoin-environment
+fi
+
+# Clean up and reset for cloudinit
+docker ps -aq | xargs -r docker rm
+docker volume ls -q | xargs -r docker volume rm
+docker images -q | xargs -r docker rmi
+systemctl stop docker.service
+
+# Run cloud-init
+coreos-cloudinit --from-file="$work_dir/cloud-config.yaml"

--- a/etcd/cloud-configs/etcd.yaml
+++ b/etcd/cloud-configs/etcd.yaml
@@ -1,0 +1,144 @@
+#cloud-config
+---
+coreos:
+  update:
+    reboot-strategy: "etcd-lock"
+  units:
+    - name: etcd2.service
+      enable: false
+      command: stop
+    - name: etcd-member.service
+      enable: true
+      command: start
+      drop-ins:
+        - name: 1-override.conf
+          content: |
+            [Unit]
+            Wants=var-lib-etcd.mount etcd-init.service
+            After=var-lib-etcd.mount etcd-init.service
+
+            [Service]
+            Environment="ETCD_IMAGE_TAG=v3.1.5"
+            Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/ca-chain.pem"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd-peer.pem"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd-peer-key.pem"
+
+            Environment="ETCD_CLIENT_CERT_AUTH=true"
+            Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/ca-chain.pem"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd-server.pem"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd-server-key.pem"
+
+            EnvironmentFile=/etc/etcd-environment
+            Environment="ETCD_DATA_DIR=/var/lib/etcd"
+            Environment="ETCD_SSL_DIR=/etc/etcd/tls"
+            Environment="ETCD_LISTEN_CLIENT_URLS=https://%H:2379"
+            Environment="ETCD_ADVERTISE_CLIENT_URLS=https://%H:2379"
+            Environment="ETCD_LISTEN_PEER_URLS=https://%H:2380"
+            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://%H:2380"
+            Environment="ETCD_OPTS="
+            PermissionsStartOnly=true
+            ExecStartPre=/usr/bin/systemctl is-active var-lib-etcd.mount
+            ExecStartPre=/usr/bin/systemctl is-active etcd-init.service
+            ExecStartPre=/usr/bin/sed -i 's/^ETCDCTL_ENDPOINT.*$/ETCDCTL_ENDPOINT=https:\/\/%H:2379/' /etc/environment
+            ExecStartPre=/usr/bin/chown -R etcd:etcd /var/lib/etcd
+    - name: etcd-init.service
+      command: start
+      content: |
+        [Unit]
+        Description=etcd init
+        Requires=prepare-tls-assets.service docker.service
+        After=prepare-tls-assets.service docker.service
+        Before=etcd-member.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        EnvironmentFile=/etc/environment
+        ExecStart=/opt/bin/etcd-init.sh
+
+        [Install]
+        WantedBy=etcd-member.service
+    - name: prepare-tls-assets.service
+      command: start
+      content: |
+        [Unit]
+        Description=Prepare etcd TLS assets
+        Before=etcd-init.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/opt/bin/prepare-tls-assets.sh
+
+        [Install]
+        RequiredBy=etcd-init.service
+    - name: var-lib-etcd.mount
+      command: start
+      content: |
+        [Unit]
+        Description=Mount disk to /var/lib/etcd
+        Requires=format-etcd-volume.service
+        After=format-format-etcd-volume.service
+        Before=etcd-member.service
+
+        [Mount]
+        What=/dev/xvdf
+        Where=/var/lib/etcd
+        Type=ext4
+
+        [Install]
+        RequiredBy=etcd-member.service
+    - name: format-etcd-volume.service
+      command: start
+      content: |
+        [Unit]
+        Description=Formats etcd EBS volume
+        After=dev-xvdf.device
+        Requires=dev-xvdf.device
+        Before=var-lib-etcd.mount
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        Environment="LABEL=var-lib-etcd"
+        Environment="DEV=/dev/xvdf"
+        # Do not wipe the disk if it's already being used, so the data is persisted across reboots.
+        ExecStart=-/bin/bash -c "if ! findfs LABEL=$LABEL > /tmp/label.$LABEL; then wipefs -a -f $DEV && mkfs.ext4 -T news -F -L $LABEL $DEV && echo wiped; fi"
+
+        [Install]
+        RequiredBy=var-lib-etcd.mount
+write_files:
+  - path: /etc/environment
+    permissions: 0644
+    content: |
+      COREOS_PUBLIC_IPV4=$public_ipv4
+      COREOS_PRIVATE_IPV4=$private_ipv4
+      ETCDCTL_CA_FILE=/etc/etcd/tls/ca-chain.pem
+      ETCDCTL_CERT_FILE=/etc/etcd/tls/etcd-client.pem
+      ETCDCTL_KEY_FILE=/etc/etcd/tls/etcd-client-key.pem
+      ETCDCTL_ENDPOINT=
+  - path: /opt/bin/prepare-tls-assets.sh
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash
+
+      mkdir -p /etc/etcd/tls
+      mv /root/cloudinit/tls/*.pem /etc/etcd/tls
+  - path: /opt/bin/etcd-init.sh
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash
+
+      # Dyamically create/join the etcd cluster by querying autoscaling group
+      image=quay.io/concur_platform/etcd-aws-operator:0.0.1
+      /usr/bin/docker run --rm \
+        --env-file=/etc/quoin-environment \
+        -v /var/run/coreos:/var/run/coreos \
+        -v /etc/etcd/tls:/etc/etcd/tls \
+        $image /etcd-aws-operator
+
+      # Place etcd-environment
+      /usr/bin/cp /var/run/coreos/etcd-environment /etc/etcd-environment

--- a/etcd/etcd.tf
+++ b/etcd/etcd.tf
@@ -1,0 +1,264 @@
+/*
+* ------------------------------------------------------------------------------
+* Variables
+* ------------------------------------------------------------------------------
+*/
+
+variable "subnet_ids" {
+  description = "A comma-separated list of subnet ids to use for the instances."
+}
+
+variable "etcd_server_cert" {
+  description = "The public certificate to be used by etcd servers encoded in base64 format."
+}
+
+variable "etcd_server_key" {
+  description = "The private key to be used by etcd servers encoded in base64 format."
+}
+
+variable "etcd_client_cert" {
+  description = "The public client certificate to be used for authenticating against etcd encoded in base64 format."
+}
+
+variable "etcd_client_key" {
+  description = "The client private key to be used for authenticating against etcd encoded in base64 format."
+}
+
+variable "etcd_peer_cert" {
+  description = "The public certificate to be used by etcd peers encoded in base64 format."
+}
+
+variable "etcd_peer_key" {
+  description = "The private key to be used by etcd peers encoded in base64 format."
+}
+
+variable "etcd_instance_type" {
+  description = "The type of instance to use for the etcd cluster. Example: 'm3.medium'"
+  default     = "m3.medium"
+}
+
+variable "etcd_min_size" {
+  description = "The minimum size for the etcd cluster. NOTE: Use odd numbers."
+  default     = "1"
+}
+
+variable "etcd_max_size" {
+  description = "The maximum size for the etcd cluster. NOTE: Use odd numbers."
+  default     = "9"
+}
+
+variable "etcd_desired_capacity" {
+  description = "The desired capacity of the etcd cluster. NOTE: Use odd numbers."
+  default     = "1"
+}
+
+variable "etcd_root_volume_size" {
+  description = "Set the desired capacity for the root volume in GB."
+  default     = "12"
+}
+
+variable "etcd_data_volume_size" {
+  description = "Set the desired capacity for the data volume used by etcd in GB."
+  default     = "12"
+}
+
+variable "key_name" {
+  description = "A name for the given key pair to use for instances."
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Resources
+* ------------------------------------------------------------------------------
+*/
+
+# Auto Scaling Group and Launch Configuration
+resource "aws_autoscaling_group" "etcd" {
+  name                 = "${format("%s", var.name)}"
+  min_size             = "${var.etcd_min_size}"
+  max_size             = "${var.etcd_max_size}"
+  desired_capacity     = "${var.etcd_desired_capacity}"
+  availability_zones   = ["${split(",", var.availability_zones)}"]
+  vpc_zone_identifier  = ["${split(",", var.subnet_ids)}"]
+  health_check_type    = "EC2"
+  force_delete         = true
+  launch_configuration = "${aws_launch_configuration.etcd.name}"
+
+  tag {
+    key                 = "Name"
+    value               = "${format("%s", var.name)}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "RoleType"
+    value               = "${var.role_type}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "CostCenter"
+    value               = "${var.cost_center}"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_launch_configuration" "etcd" {
+  name_prefix          = "${format("%s-", var.name)}"
+  image_id             = "${data.aws_ami.coreos_ami.id}"
+  instance_type        = "${var.etcd_instance_type}"
+  iam_instance_profile = "${aws_iam_instance_profile.etcd.name}"
+  security_groups      = ["${aws_security_group.etcd.id}"]
+  key_name             = "${var.key_name}"
+  depends_on           = ["aws_s3_bucket.cluster", "aws_s3_bucket_object.etcd", "aws_iam_instance_profile.etcd", "aws_security_group.etcd"]
+
+  # /root
+  root_block_device = {
+    volume_type = "gp2"
+    volume_size = "${var.etcd_root_volume_size}"
+  }
+
+  # /var/lib/etcd
+  ebs_block_device = {
+    device_name = "/dev/sdf"
+    encrypted   = true
+    volume_type = "gp2"
+    volume_size = "${var.etcd_data_volume_size}"
+  }
+
+  user_data = "${data.template_file.s3_cloudconfig_bootstrap.rendered}"
+}
+
+# Security Group
+resource "aws_security_group" "etcd" {
+  name       = "${format("%s-%s", var.name, element(split("-", var.vpc_id), 1))}"
+  vpc_id     = "${var.vpc_id}"
+  depends_on = ["aws_security_group.bastion"]
+
+  # Allow SSH from the bastion
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.bastion.id}"]
+  }
+
+  # Allow etcd peers to communicate, include etcd proxies
+  ingress {
+    from_port   = 2380
+    to_port     = 2380
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr}"]
+  }
+
+  # Allow etcd clients to communicate
+  ingress {
+    from_port   = 2379
+    to_port     = 2379
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr}"]
+  }
+
+  # Allow all outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${format("%s", var.name)}"
+  }
+}
+
+# Etcd cloud-config
+resource "aws_s3_bucket_object" "etcd" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/etcd/cloud-config.yaml"
+  content = "${data.template_file.etcd.rendered}"
+}
+
+# Certificates
+resource "aws_s3_bucket_object" "etcd_server_cert" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/etcd/tls/etcd-server.pem.enc.base"
+  content = "${var.etcd_server_cert}"
+}
+
+resource "aws_s3_bucket_object" "etcd_server_key" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/etcd/tls/etcd-server-key.pem.enc.base"
+  content = "${var.etcd_server_key}"
+}
+
+resource "aws_s3_bucket_object" "etcd_client_cert" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/common/tls/etcd-client.pem.enc.base"
+  content = "${var.etcd_client_cert}"
+}
+
+resource "aws_s3_bucket_object" "etcd_client_key" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/common/tls/etcd-client-key.pem.enc.base"
+  content = "${var.etcd_client_key}"
+}
+
+resource "aws_s3_bucket_object" "etcd_peer_cert" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/etcd/tls/etcd-peer.pem.enc.base"
+  content = "${var.etcd_peer_cert}"
+}
+
+resource "aws_s3_bucket_object" "etcd_peer_key" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/etcd/tls/etcd-peer-key.pem.enc.base"
+  content = "${var.etcd_peer_key}"
+}
+
+# Profile, Role, and Policy
+resource "aws_iam_instance_profile" "etcd" {
+  name       = "${format("%s", var.name)}"
+  roles      = ["${aws_iam_role.etcd.name}"]
+  depends_on = ["aws_iam_role.etcd", "aws_iam_role_policy.etcd_policy"]
+}
+
+resource "aws_iam_role_policy" "etcd_policy" {
+  name       = "${format("%s-policy", var.name)}"
+  role       = "${aws_iam_role.etcd.id}"
+  policy     = "${data.template_file.etcd_policy.rendered}"
+  depends_on = ["aws_iam_role.etcd", "data.template_file.etcd_policy"]
+}
+
+resource "aws_iam_role" "etcd" {
+  name               = "${format("%s", var.name)}"
+  path               = "/"
+  assume_role_policy = "${file(format("%s/policies/assume-role-policy.json", path.module))}"
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Data Sources
+* ------------------------------------------------------------------------------
+*/
+
+# Templates
+data "template_file" "etcd_policy" {
+  template = "${file(format("%s/policies/etcd-policy.json", path.module))}"
+
+  vars {
+    name        = "${var.name}"
+    kms_key_arn = "${var.kms_key_arn}"
+  }
+}
+
+data "template_file" "etcd" {
+  template = "${file(format("%s/cloud-configs/etcd.yaml", path.module))}"
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Outputs
+* ------------------------------------------------------------------------------
+*/
+

--- a/etcd/main.tf
+++ b/etcd/main.tf
@@ -1,0 +1,109 @@
+/*
+* ------------------------------------------------------------------------------
+* Variables
+* ------------------------------------------------------------------------------
+*/
+
+variable "name" {
+  description = "The name of your quoin."
+}
+
+variable "region" {
+  description = "Region where resources will be created."
+}
+
+variable "role_type" {
+  description = "The role type to attach resource usage."
+}
+
+variable "cost_center" {
+  description = "The cost center to attach resource usage."
+}
+
+variable "kms_key_arn" {
+  description = "The arn associated with the encryption key used for encrypting the certificates."
+}
+
+variable "root_cert" {
+  description = "The root certificate authority that all certificates belong to encoded in base64 format."
+}
+
+variable "intermediate_cert" {
+  description = "The intermediate certificate authority that all certificates belong to encoded in base64 format."
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to create the resources within."
+}
+
+variable "vpc_cidr" {
+  description = "A CIDR block for the VPC that specifies the set of IP addresses to use."
+}
+
+variable "availability_zones" {
+  description = "Comma separated list of availability zones for a region."
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Resources
+* ------------------------------------------------------------------------------
+*/
+
+# Certificates
+resource "aws_s3_bucket_object" "root_cert" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/common/tls/root-ca.pem.enc.base"
+  content = "${var.root_cert}"
+}
+
+resource "aws_s3_bucket_object" "intermediate_cert" {
+  bucket  = "${aws_s3_bucket.cluster.bucket}"
+  key     = "cloudinit/common/tls/intermediate-ca.pem.enc.base"
+  content = "${var.intermediate_cert}"
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Data Sources
+* ------------------------------------------------------------------------------
+*/
+
+data "template_file" "s3_cloudconfig_bootstrap" {
+  template = "${file(format("%s/bootstrapper/s3-cloudconfig-bootstrap.sh", path.module))}"
+
+  vars {
+    name = "${var.name}"
+  }
+}
+
+# Latest stable CoreOS AMI
+data "aws_ami" "coreos_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CoreOS-stable-*-hvm"]
+  }
+}
+
+/*
+* ------------------------------------------------------------------------------
+* Outputs
+* ------------------------------------------------------------------------------
+*/
+
+# The name of our quoin
+output "name" {
+  value = "${var.name}"
+}
+
+# The region where the quoin lives
+output "region" {
+  value = "${var.region}"
+}
+
+# The CoreOS AMI ID
+output "coreos_ami" {
+  value = "${data.aws_ami.coreos_ami.id}"
+}

--- a/etcd/policies/assume-role-policy.json
+++ b/etcd/policies/assume-role-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/etcd/policies/etcd-policy.json
+++ b/etcd/policies/etcd-policy.json
@@ -1,0 +1,36 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::concur-${name}",
+        "arn:aws:s3:::concur-${name}/cloudinit",
+        "arn:aws:s3:::concur-${name}/cloudinit/common/tls/*",
+        "arn:aws:s3:::concur-${name}/cloudinit/etcd/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": [
+        "${kms_key_arn}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:Describe*",
+        "autoscaling:Describe*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/etcd/s3.tf
+++ b/etcd/s3.tf
@@ -1,0 +1,20 @@
+/*
+* ------------------------------------------------------------------------------
+* Resources
+* ------------------------------------------------------------------------------
+*/
+
+# NOTE: s3 bucket requires gloabl unique bucket name
+# Convention: concur-<name> for the prefix
+
+# s3 bucket for initial-cluster etcd proxy discovery
+# and two-stage cloudinit user-data files
+resource "aws_s3_bucket" "cluster" {
+  bucket        = "${format("concur-%s", var.name)}"
+  acl           = "private"
+  force_destroy = true
+
+  tags {
+    Name = "${var.name}"
+  }
+}

--- a/kubernetes/images/etcd-aws-operator/etcd-aws-operator
+++ b/kubernetes/images/etcd-aws-operator/etcd-aws-operator
@@ -91,6 +91,7 @@ get_members() {
       *$instance_hostname*) continue;;
     esac
 
+    # TODO(weitengh): Find out etcd3 endpoint for list of members ($url/v2/members)
     local _etcd_members_response="$(run curl -f -s --cacert $ca_cert --cert $etcd_client_cert --key $etcd_client_key $url/v2/members)"
     if [ "$_etcd_members_response" ]; then
       _etcd_members="$_etcd_members_response"
@@ -154,7 +155,7 @@ join_existing_cluster() {
   local _etcd_member_url="$(get_member_url $_etcd_members)"
   assert_nz "$_etcd_member_url" "Unable to find a member url: $_etcd_members"
   say "Using member url: $_etcd_member_url"
-  
+
   # Before joining, remove any bad members from the cluster
   remove_bad_members $_etcd_members
 


### PR DESCRIPTION
  - Launches an etcd v3 cluster in AWS using auto-scaling group and
    launch configuration.
  - Use clould-config to provision the instance with the appropriate
    certs and cluster membership.
  - Pull key pair out of etcd and provide variable
  - Use cloud-config to configure etcd3 environment variables
  - Use cloud-config to start etcd3 service: etcd-memeber.service
  - etcd-memeber.service running as rkt container
  - etcd-memeber.service start with etcd-wrapper script
  - Update cloud-config to align with etcd2 configuration
  - Remove etcd quoin "-etcd" naming enforcement
  - Add TODO on etcd aws operator container script