### PR TITLE
Add internal ELB for Vault

### DIFF
--- a/vault/cloud-configs/vault.yaml
+++ b/vault/cloud-configs/vault.yaml
@@ -188,8 +188,8 @@ write_files:
           etcd_api = "v3"
           ha_enabled = "true"
           tls_ca_file = "/opt/etc/tls/ca-chain.pem"
-          tls_cert_file = "/opt/etc/tls/etcd-client.pem"
-          tls_key_file = "/opt/etc/tls/etcd-client-key.pem"
+          tls_cert_file = "/opt/etc/tls/vault-etcd-client.pem"
+          tls_key_file = "/opt/etc/tls/vault-etcd-client-key.pem"
       }
 
       listener "tcp" {


### PR DESCRIPTION
  - Once the vault cluster is initialized and unsealed, one vault
    instance will show InService, while the other ones show
    OutOfService. This is the way Vault operates in HA mode. The
    /health endpoint will return 200 when the instance is the leader.
    While the other instances will return 429, which means unsealed
    and standby.
  - Also be more explicit on the client certificate used by vault
    for etcd interactions.